### PR TITLE
ci: remove git-path option

### DIFF
--- a/.github/workflows/site-release.yaml
+++ b/.github/workflows/site-release.yaml
@@ -32,7 +32,6 @@ jobs:
           skip-commit: "true"
           skip-git-pull: "true"
           skip-tag: "true"
-          git-path: "site locations"
   build:
     needs: get-version
     runs-on: ubuntu-latest
@@ -93,7 +92,6 @@ jobs:
           skip-commit: "true"
           skip-git-pull: "true"
           skip-tag: "false"
-          git-path: "site locations"
       - name: Create Release
         uses: actions/create-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}


### PR DESCRIPTION
no possibility to add multiple paths so we remove it temporarely