### PR TITLE
feat: add option for model override

### DIFF
--- a/locations/.shared/DefaultMealChat.py
+++ b/locations/.shared/DefaultMealChat.py
@@ -18,6 +18,7 @@ class DefaultMealChat:
         self.prompt_config = prompt_config
         print("prompt_config: " + str(self.prompt_config))
         if promptOverrides is not None:
+            print("promptOverrides: " + str(promptOverrides))
             self.prompt_config.update(promptOverrides)
         # if dateOverride is set, use it
         if dateOverride is not None:
@@ -118,7 +119,7 @@ class DefaultMealChat:
         ]})
         
         print(f"sending additional user msg: {self.userMessagePrefix + self.userMessage}")
-        chat_completion = client.chat.completions.create(model="gpt-4o",
+        chat_completion = client.chat.completions.create(model=self.prompt_config["visionModel"],
                                                         messages=gpt_messages,
                                                         max_tokens=self.max_tokens)#,
                                                         #response_format={ "type":"json_object" })

--- a/locations/.shared/prompt_config.py
+++ b/locations/.shared/prompt_config.py
@@ -32,5 +32,6 @@ prompt_config = {
     ]
   }""",
   "addCurrentDate": True,
-  "addCurrentWeekdays": True
+  "addCurrentWeekdays": True,
+  "visionModel": "gpt-4o"
 }


### PR DESCRIPTION
adds the possibility to override the vision model but I discovered while gpt-4o-mini is much cheaper on all the tokens than gpt-4o the actual token usage for images gets multiplied by a factor which makes it even more expensive than gpt-4o. as the output quality of gpt-4o-mini is not equal to gpt-4o we will stick with that